### PR TITLE
Fixes #61

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,17 +1,17 @@
 import { promises as fs ,existsSync} from "fs";
-import {createIfNot} from "./utils/fileUtils.js"
 import * as  path from "node:path"
+
 async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = false) {
   try {
-    const destinationFile = process.argv[2] || saveFileAs;
+    const destinationFile = saveFileAs || "";
     if (!destinationFile) {
       throw new Error("Missing saveFileAs parameter");
     }
-    createIfNot(path.resolve(`./sql/${destinationFile}.sql`))
+
 		if(isAppend){
-      await fs.appendFile(`sql/${process.argv[2]}.sql`, statement);
+      await fs.appendFile(`sql/${saveFileAs}.sql`, statement);
     }else{
-      await fs.writeFile(`sql/${process.argv[2]}.sql`, statement);
+      await fs.writeFile(`sql/${saveFileAs}.sql`, statement);
     }
   } catch (err) {
     console.log(err);
@@ -20,8 +20,8 @@ async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = 
 
 async function readCSV(csvFileName = "", batchSize: number = 0) {
   try {
-    const fileAndTableName = process.argv[2] || csvFileName;
-    
+    const fileAndTableName = csvFileName || "";
+
     batchSize = parseInt(process.argv[3]) || batchSize || 500;
 		let isAppend: boolean = false;
 
@@ -55,15 +55,15 @@ async function readCSV(csvFileName = "", batchSize: number = 0) {
       // Check batch size (rows per batch)
       if(index > 0 && index % batchSize == 0){
         values = values.slice(0, -2) + ";\n\n";
-    
+
         const sqlStatement = beginSQLInsert + values;
-    
-        // Write File 
+
+        // Write File
         writeSQL(sqlStatement, fileAndTableName, isAppend);
         values = "";
         isAppend = true;
       }
-      
+
       let valueLine = "\t(";
       arr.forEach((value) => {
         // Matches NULL values, Numbers,
@@ -91,5 +91,9 @@ async function readCSV(csvFileName = "", batchSize: number = 0) {
     console.log(err);
   }
 }
-readCSV();
+
+const files = process.argv.slice(2)
+let promises = files.map(file => readCSV(file))
+Promise.all(promises).then(console.log)
+
 console.log("Finished!");

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import { promises as fs ,existsSync} from "fs";
+import {createIfNot} from "./utils/fileUtils.js"
 import * as  path from "node:path"
 
 async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = false) {
@@ -7,6 +8,8 @@ async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = 
     if (!destinationFile) {
       throw new Error("Missing saveFileAs parameter");
     }
+
+    createIfNot(path.resolve('./sql/'))
 
 		if(isAppend){
       await fs.appendFile(`sql/${saveFileAs}.sql`, statement);


### PR DESCRIPTION
- Updating path in createIfNot resolves the bug to create sql folder in root directory if not exists
- Allow multiple file names to be input in npm start command and output multiple sql files (i.e npm start ExampleTable ExampleTable2 ExampleTable3 will create .sql files for each file name)