### PR TITLE
Fixes [Issue #31]  : Added a command line argument "all".

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,22 +1,24 @@
 import fs from "node:fs/promises"
 import { existsSync } from "node:fs"
-import { createIfNot } from "./utils/fileUtils.mjs"
+import { createIfNot } from "./utils/fileUtils.js"
 import path from "node:path"
+
 async function writeSQL(statement, saveFileAs = "") {
   try {
-    const destinationFile = process.argv[2] || saveFileAs
+    const destinationFile = saveFileAs;
     if (!destinationFile) {
       throw new Error("Missing saveFileAs parameter")
     }
     createIfNot(path.resolve(`./sql/${destinationFile}`))
-    await fs.writeFile(`sql/${process.argv[2]}.sql`, statement)
+    await fs.writeFile(`sql/${destinationFile}.sql`, statement)
   } catch (err) {
     console.log(err)
   }
 }
+
 async function readCSV(csvFileName = "") {
   try {
-    const fileAndTableName = process.argv[2] || csvFileName
+    const fileAndTableName = csvFileName;
     if (!fileAndTableName) {
       throw new Error("Missing csvFileName parameter")
     }
@@ -27,6 +29,7 @@ async function readCSV(csvFileName = "") {
     const data = await fs.readFile(`csv/${fileAndTableName}.csv`, {
       encoding: "utf8",
     })
+
     const linesArray = data.split(/\r|\n/).filter(line => line)
     const columnNames = linesArray.shift().split(",")
     let beginSQLInsert = `INSERT INTO ${fileAndTableName} (`
@@ -70,5 +73,8 @@ async function readCSV(csvFileName = "") {
     console.log(err)
   }
 }
-readCSV()
+
+var args = process.argv[2];
+readCSV(args);
+
 console.log("Finished!")

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
   "main": "index.js",
   "scripts": {
     "start": "npm run build && node dist/index.js",
-    "build": "tsc  --skipLibCheck"
+    "build": "tsc  --skipLibCheck",
+    "lint": "eslint --ext .ts src/",
+    "dev": "nodemon --watch 'src/**/*.ts' --exec 'ts-node' src/index.ts"
   },
   "author": {
     "name": "Dave Gray",

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,15 +3,15 @@ import {createIfNot} from "./utils/fileUtils.js"
 import * as  path from "node:path"
 async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = false) {
   try {
-    const destinationFile = process.argv[2] || saveFileAs;
+    const destinationFile = saveFileAs;
     if (!destinationFile) {
       throw new Error("Missing saveFileAs parameter");
     }
     createIfNot(path.resolve(`./sql/${destinationFile}.sql`))
 		if(isAppend){
-      await fs.appendFile(`sql/${process.argv[2]}.sql`, statement);
+      await fs.appendFile(`sql/${destinationFile}.sql`, statement);
     }else{
-      await fs.writeFile(`sql/${process.argv[2]}.sql`, statement);
+      await fs.writeFile(`sql/${destinationFile}.sql`, statement);
     }
   } catch (err) {
     console.log(err);
@@ -20,7 +20,7 @@ async function writeSQL(statement: string, saveFileAs = "", isAppend: boolean = 
 
 async function readCSV(csvFileName = "", batchSize: number = 0) {
   try {
-    const fileAndTableName = process.argv[2] || csvFileName;
+    const fileAndTableName = csvFileName;
     
     batchSize = parseInt(process.argv[3]) || batchSize || 500;
 		let isAppend: boolean = false;
@@ -91,5 +91,20 @@ async function readCSV(csvFileName = "", batchSize: number = 0) {
     console.log(err);
   }
 }
-readCSV();
+var args = process.argv[2];
+if(args === "all") {
+  const files = await fs.readdir("./csv")
+  files.forEach(file => {
+    if(file.includes(".csv")) {
+      const tableName = file.slice(0, -4);
+      console.log(`Reading ${tableName}...`);
+      readCSV(tableName);
+    }
+  })
+}
+else{
+  console.log(`Reading ${args}...`);
+  readCSV(args)
+}
+
 console.log("Finished!");

--- a/src/utils/fileUtils.ts
+++ b/src/utils/fileUtils.ts
@@ -1,4 +1,5 @@
 import * as fs from "node:fs"
+
 export function createIfNot(dir:string) {
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir, { recursive: true })

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
-    "target": "es6",
-    "module": "ES2020",
+    "target": "es2017",
+    "module": "esnext",
     "outDir": "./dist",
     "rootDir": "./src",
     "strict": true,


### PR DESCRIPTION
Fixes [Issue #31] [Issue #3]

Added a command line argument "all" for processing all the files, exist in the ./csv folder.
Example: npm start all --- for processing all the files, else npm start fileName ---- for a specific file